### PR TITLE
Memory leak during iterparse

### DIFF
--- a/xml2csv.py
+++ b/xml2csv.py
@@ -79,6 +79,8 @@ for event, elem in context:
 	if n == args.limit:
 		break
 
+	elem.clear() # discard element and recover memory
+
 
 write_buffer()
 show_stats()

--- a/xml2sql.py
+++ b/xml2sql.py
@@ -98,6 +98,8 @@ for event, elem in context:
 	if n == args.limit:
 		break
 
+	elem.clear() # discard element and recover memory
+
 
 write_buffer()
 show_stats()


### PR DESCRIPTION
Every element created by iterparse must be explicitly deleted using `elem.clear()` to free up the allocated memory.

I've confirmed this makes a significant improvement while using a 17 GB input file :)

More info: http://eli.thegreenplace.net/2012/03/15/processing-xml-in-python-with-elementtree/#xml-stream-parsing-with-iterparse
