### PR TITLE
Removed the `#` prefix in the header line of generated CSV files

### DIFF
--- a/samples/fruits.csv
+++ b/samples/fruits.csv
@@ -1,4 +1,4 @@
-#id,name,price,quantity
+id,name,price,quantity
 "1000","Apple","4","133"
 "1001","Apricot","5","175"
 "1002","Avocado","5","182"

--- a/xmlutils/xml2csv.py
+++ b/xmlutils/xml2csv.py
@@ -90,7 +90,7 @@ class xml2csv:
 				elif elem.tag == tag and len(items) > 0:
 					# csv header (element tag names)
 					if header_line and not tagged:
-						self.output.write('#' + delimiter.join(header_line) + '\n')
+						self.output.write(delimiter.join(header_line) + '\n')
 					tagged = True
 
 					# send the csv to buffer


### PR DESCRIPTION
Closes #13.
