### PR TITLE
Double-quotes are escaped by preceding them with another double-quote

### DIFF
--- a/xmlutils/xml2csv.py
+++ b/xmlutils/xml2csv.py
@@ -84,7 +84,7 @@ class xml2csv:
 						header_line.append(field_name)  # add field name to csv header
 						# remove current tag from the tag name chain
 						field_name = field_name.rpartition('_' + elem.tag)[0]
-					items.append('' if elem.text is None else elem.text.strip().replace('"', r'\"'))
+					items.append('' if elem.text is None else elem.text.strip().replace('"', r'""'))
 
 				# end of traversing the record tag
 				elif elem.tag == tag and len(items) > 0:


### PR DESCRIPTION
As per [RFC 4180 Section 2.7](http://tools.ietf.org/html/rfc4180#section-2):

> If double-quotes are used to enclose fields, then a double-quote
> appearing inside a field must be escaped by preceding it with another
> double quote.
