### PR TITLE
Fix for python 3.X: iter.next() in py2 becomes next(iter) in py3

### DIFF
--- a/xmlutils/xml2csv.py
+++ b/xmlutils/xml2csv.py
@@ -54,13 +54,19 @@ class xml2csv:
         """
 
         # get to the root
-        # try-catch to ensure support for python 2/3 versions: iter.next() in python 2 changed to next(iter) in python 3
+        # to ensure support for python 2/3 versions: iter.next() in python 2 changed to next(iter) in python 3
         try:
-            # for py version 2.x
-            event, root = self.context.next()
-        except AttributeError:
-            # for py version 3.x
-            event, root = next(self.context)
+            try:
+                # for py version 2.x
+                event, root = self.context.next()
+            except AttributeError:
+                # for py version 3.x
+                event, root = next(self.context)
+        except et.ParseError as e:
+            # Invalid XML file - so close the file handle and delete it
+            self.output.close()
+            os.remove(self.input_file)
+            raise e
 
         items = []
         header_line = []

--- a/xmlutils/xml2csv.py
+++ b/xmlutils/xml2csv.py
@@ -54,7 +54,13 @@ class xml2csv:
         """
 
         # get to the root
-        event, root = self.context.next()
+        # try-catch to ensure support for python 2/3 versions: iter.next() in python 2 changed to next(iter) in python 3
+        try:
+            # for py version 2.x
+            event, root = self.context.next()
+        except AttributeError:
+            # for py version 3.x
+            event, root = next(self.context)
 
         items = []
         header_line = []


### PR DESCRIPTION
Python 3.x related changes and error handling for invalid XML file